### PR TITLE
fix types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,7 +137,7 @@ class Bee {
     )
   }
 
-  load = (template: Record<string, unknown>) => this.executeAction(LOAD, template)
+  load = (template: IEntityContentJson) => this.executeAction(LOAD, template)
 
   save = () => this.executeAction(SAVE)
 
@@ -157,7 +157,7 @@ class Bee {
 
   showComment = (comment) => this.executeAction(SHOW_COMMENT, comment) 
 
-  reload = (template: Record<string, unknown>, options?: IBeeOptions) => this.executeAction(RELOAD, template, options)
+  reload = (template: IEntityContentJson, options?: IBeeOptions) => this.executeAction(RELOAD, template, options)
 
   loadWorkspace = (type: LoadWorkspaceOptions) => this.executeAction(LOAD_WORKSPACE, type)
 

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -343,7 +343,16 @@ export interface IBeeConfig {
   rowsConfiguration?: { 
     defaultRows?: boolean,
     emptyRows?: boolean,
-    externalContentURLs?: Array<{name: string, value: string, id?: string | number}>
+    externalContentURLs?: Array<{
+      name: string
+      value: string
+      id?: string | number
+      handle?: string
+      behaviors?: {
+        canEdit?: boolean,
+        canDelete?: boolean,
+      },
+    }>
   }
   hooks?: BeePluginConfigurationsHooks
   onLoad: () => void

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -189,6 +189,7 @@ export interface IMergeTag {
   name: string
   value: string
   id?: number
+  previewValue?: string
 }
 export interface IMergeContent {
   name: string

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -340,7 +340,11 @@ export interface IBeeConfig {
       handler: BeePluginContentDialogHandler<IRefreshSavedRow>
     }
   },
-  rowsConfiguration?: Record<string, unknown>
+  rowsConfiguration?: { 
+    defaultRows?: boolean,
+    emptyRows?: boolean,
+    externalContentURLs?: Array<{name: string, value: string}>
+  }
   hooks?: BeePluginConfigurationsHooks
   onLoad: () => void
   onPreview?: () => void

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -343,7 +343,7 @@ export interface IBeeConfig {
   rowsConfiguration?: { 
     defaultRows?: boolean,
     emptyRows?: boolean,
-    externalContentURLs?: Array<{name: string, value: string}>
+    externalContentURLs?: Array<{name: string, value: string, id?: string | number}>
   }
   hooks?: BeePluginConfigurationsHooks
   onLoad: () => void


### PR DESCRIPTION
This adds the previewValue type to the IMergeTag as described in your docs [here](https://docs.beefree.io/smart-merge-tags/), as well as support the `IEntityContentJson` type when loading or reloading a template.