### PR TITLE
feat: use loader v2, exposed getConfig method

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -54,6 +54,7 @@
                 <div id="trigger-loadStageMode"  class="item-dropdown" type="button" value="stage mode"></i>load stage mode</div>
                 <div id="trigger-loadConfig"  class="item-dropdown" type="button" value="load config"></i>reload client config</div>
                 <div id="trigger-updateToken"  class="item-dropdown" type="button" value="update token"></i>update token</div>
+                <div id="trigger-getConfig"  class="item-dropdown" type="button" value="Get config"></i>Get Config</div>
               </div>
             </div>
         </span>

--- a/example/integration.ts
+++ b/example/integration.ts
@@ -272,6 +272,11 @@ const addEvents = () => {
       defaultRows: true
     }
   }), false)
+
+  window.document.getElementById('trigger-getConfig')?.addEventListener('click', () => {
+    const config = beeTest.getConfig()
+    console.log('config --> ', config)
+  }, false)
 }
 
 const conf = { authUrl: API_AUTH_URL, beePluginUrl: BEEJS_URL }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import * as beeTypes from './types/bee'
 //this is the global variable injected from BeePlugin.js 
 declare let BeePlugin: any;
 
-const BEEJS_URL = 'https://app-rsrc.getbee.io/plugin/BeePlugin.js'
+const BEEJS_URL = 'https://app-rsrc.getbee.io/plugin/v2/BeePlugin.js'
 
 const API_AUTH_URL = 'https://auth.getbee.io/apiauth'
 
@@ -49,7 +49,8 @@ const {
   LOAD_STAGE_MODE,
   LOAD_CONFIG,
   LOAD_ROWS,
-  UPDATE_TOKEN
+  UPDATE_TOKEN,
+  GET_CONFIG
 } = beeActions
 
 class Bee {
@@ -141,6 +142,14 @@ class Bee {
     )
   }
 
+  executeGetConfigAction = () :IBeeConfig => {
+    const { instance } = this
+
+    return instance[GET_CONFIG]()
+  }
+
+  
+
   load = (template: IEntityContentJson) => this.executeAction(LOAD, template)
 
   loadRows = () => this.executeAction(LOAD_ROWS)
@@ -173,6 +182,7 @@ class Bee {
 
   updateToken = (updateTokenArgs: IToken) => this.executeAction(UPDATE_TOKEN, updateTokenArgs)
 
+  getConfig = () => this.executeGetConfigAction()
 }
 
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -19,7 +19,8 @@ const beeActions = {
   LOAD_STAGE_MODE: 'loadStageMode',
   LOAD_CONFIG: 'loadConfig',
   LOAD_ROWS: 'loadRows',
-  UPDATE_TOKEN: 'updateToken'
+  UPDATE_TOKEN: 'updateToken',
+  GET_CONFIG: 'getConfig'
 }
 
 export const mockedEmptyToken : IToken = {


### PR DESCRIPTION
## Description

- Use loader v2
- Exposed getConfig method

## Motivation and Context

Loader v2 resolves many knows issues. The getConfig method retrieve the internal clientConfig used by sdk and can be useful to the consumer

## Usage examples

```js
import BeePLugin from '@mailupinc/bee-plugin'

const beePlugin = new BeePlugin()
const clientConfig = beePlugin.getConfig()
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
