### PR TITLE
feat(multilanguage): switch template language method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import {
   IBeeConfig, IEntityContentJson,
   IBeeLoader, IBeeOptions, ILoadConfig,
   ILoadStageMode, IUrlConfig, LoadWorkspaceOptions,
-  ISwitchLanguageTemplate,
+  ISwitchTemplateLanguage,
   IToken, BeeSaveOptions
 } from './types/bee'
 import beeActions, { mockedEmptyToken } from './utils/Constants'
@@ -175,7 +175,7 @@ class Bee {
 
   updateToken = (updateTokenArgs: IToken) => this.executeAction(UPDATE_TOKEN, updateTokenArgs)
 
-  switchTemplateLanguage = (language: ISwitchLanguageTemplate) => this.executeAction(SWITCH_TEMPLATE_LANGUAGE, language)
+  switchTemplateLanguage = (language: ISwitchTemplateLanguage) => this.executeAction(SWITCH_TEMPLATE_LANGUAGE, language)
 
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import {
   IBeeConfig, IEntityContentJson,
   IBeeLoader, IBeeOptions, ILoadConfig,
   ILoadStageMode, IUrlConfig, LoadWorkspaceOptions,
+  ISwitchLanguageTemplate,
   IToken, BeeSaveOptions
 } from './types/bee'
 import beeActions, { mockedEmptyToken } from './utils/Constants'
@@ -49,7 +50,8 @@ const {
   LOAD_STAGE_MODE,
   LOAD_CONFIG,
   LOAD_ROWS,
-  UPDATE_TOKEN
+  UPDATE_TOKEN,
+  SWITCH_TEMPLATE_LANGUAGE
 } = beeActions
 
 class Bee {
@@ -172,6 +174,8 @@ class Bee {
   loadConfig = (args: ILoadConfig) => this.executeAction(LOAD_CONFIG, args)
 
   updateToken = (updateTokenArgs: IToken) => this.executeAction(UPDATE_TOKEN, updateTokenArgs)
+
+  switchTemplateLanguage = (language: ISwitchLanguageTemplate) => this.executeAction(SWITCH_TEMPLATE_LANGUAGE, language)
 
 }
 

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -44,6 +44,10 @@ export interface ILoadStageMode {
   display: StageDisplayOptions
 }
 
+export interface ISwitchLanguageTemplate {
+  language: string
+}
+
 export type ILoadConfig = ILoadableProps
 
 export enum LoadWorkspaceOptions {

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -44,7 +44,7 @@ export interface ILoadStageMode {
   display: StageDisplayOptions
 }
 
-export interface ISwitchLanguageTemplate {
+export interface ISwitchTemplateLanguage {
   language: string
 }
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -19,7 +19,8 @@ const beeActions = {
   LOAD_STAGE_MODE: 'loadStageMode',
   LOAD_CONFIG: 'loadConfig',
   LOAD_ROWS: 'loadRows',
-  UPDATE_TOKEN: 'updateToken'
+  UPDATE_TOKEN: 'updateToken',
+  SWITCH_TEMPLATE_LANGUAGE: 'switchTemplateLanguage'
 }
 
 export const mockedEmptyToken : IToken = {


### PR DESCRIPTION
## Description

Adds type specifications for switchTemplateLanguage method

## Motivation and Context

Fully leverage multi language templates

## Usage examples

```js
import BeePLugin from '@mailupinc/bee-plugin'

const beePlugin = new BeePlugin()
beePlugin.getToken()

const beeConfig :IBeeConfig = {
templateLanguage: { value: "de-DE", label: "Deutsch" },
  templateLanguages: [
      { value: "de-DE", label: "Deutsch" },
      { value: "fr-FR", label: "Français" },
      { value: "it-IT", label: "Italiano" }
  ],
}

beeTest.switchTemplateLanguage({language: "de-DE"});
```


## How Has This Been Tested?

Extended example application with a language switcher that executes switchTemplateLanguage({language: "de-DE"}) on the bee instance

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
