### PR TITLE
chore: added content dialog row display conditions type

### DIFF
--- a/example/integration.ts
+++ b/example/integration.ts
@@ -4,7 +4,7 @@ import {
   ContentDefaults,
   IAddOnResponseImage,
   IBeeConfig, IMergeContent, IMergeTag, ISpecialLink,
-  LoadWorkspaceOptions, ModuleDescriptorOrderNames, StageDisplayOptions, StageModeOptions, TokenStatus
+  LoadWorkspaceOptions, ModuleDescriptorOrderNames, RowDisplayConditionsHandler, StageDisplayOptions, StageModeOptions, TokenStatus
 } from '../src/types/bee';
 declare let saveAs: any;
 
@@ -68,6 +68,16 @@ const handleImageAddOnResponse = (resolve) => {
   }
   return resolve(mockedAddOnResponse)
 }
+const handleRowDisplayConditionsResponse = (resolve) => {
+  const mockedRowDisplayConditions: RowDisplayConditionsHandler = {
+    after: 'sample-after',
+    before: 'sample-before',
+    description: 'sample-description',
+    label: 'sample-label',
+    type: 'sample-type',
+  }
+  return resolve(mockedRowDisplayConditions)
+}
 
 const contentDialogs: BeeContentDialogs = {
   filePicker: {
@@ -87,6 +97,10 @@ const contentDialogs: BeeContentDialogs = {
   addOn: {
     label: 'Add On',
     handler: handleImageAddOnResponse
+  },
+  rowDisplayConditions: {
+    label: 'Row Display Conditions',
+    handler: handleRowDisplayConditionsResponse
   }
 }
 

--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -716,6 +716,14 @@ export type MergeContentsHandler = {
   value: string
 }
 
+export type RowDisplayConditionsHandler = {
+  after: string
+  before: string
+  type: string
+  label: string
+  description: string
+}
+
 export const RowLayoutType = {
   ONE_COLUMNS_EMPTY: 'one-column-empty',
   TWO_COLUMNS_EMPTY: 'two-columns-empty',
@@ -1805,6 +1813,10 @@ export type BeeContentDialogs = {
   mergeContents?: {
     label?: string
     handler: BeePluginContentDialogHandler<MergeContentsHandler>
+  }
+  rowDisplayConditions?: {
+    label?: string
+    handler: BeePluginContentDialogHandler<RowDisplayConditionsHandler>
   }
 }
 


### PR DESCRIPTION
## Description

Added rowDisplayConditions content dialog type

## Motivation and Context

Close https://github.com/BeefreeSDK/beefree-sdk-npm-official/issues/139

## Usage examples

```js
import BeeSDK from '@mailupinc/bee-plugin'

const sdk = new BeeSDK()
sdk.getToken()

const handleRowDisplayConditionsResponse = (resolve) => {
  const mockedRowDisplayConditions: RowDisplayConditionsHandler = {
    after: 'sample-after',
    before: 'sample-before',
    description: 'sample-description',
    label: 'sample-label',
    type: 'sample-type',
  }
  return resolve(mockedRowDisplayConditions)
}

const beeConfig :IBeeConfig = {
   ...,
   contentDialogs: {
     rowDisplayConditions: {
        label: 'Row Display Conditions',
        handler: handleRowDisplayConditionsResponse
      }
   }
}

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
