### PR TITLE
fix: fixed broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ builder.start(beeConfig, template)
 ```
 
 ## Configuring the editor (beeConfig)
-> It requires a configuration for using the editor, beefree help documentation portal [has a nice post](http://help.beefree.io/hc/en-us/articles/202991192-Initializing-the-plugin) explaining how to do it
+> It requires a configuration for using the editor, beefree help documentation portal [has a nice post](https://docs.beefree.io/beefree-sdk/getting-started/readme/installation/configuration-parameters) explaining how to do it
 
 Here is an example of the configuration; just read the official documentation for an extended version.
 


### PR DESCRIPTION
## Description

Fixed configuration / (beeConfig) docs link to point to the correct location in the Beefree SDK documentation. The previous URL ([https://docs.beefree.io/beefree-sdk/initializing-bee-plugin](https://docs.beefree.io/beefree-sdk/initializing-bee-plugin)) led to a 'Page not found' error.

## Motivation and Context

Documentation improvement 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
