### PR TITLE
chore: upgrade action checkout and cache versions

### DIFF
--- a/.github/workflows/cy.yml
+++ b/.github/workflows/cy.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         node-version: [14.x, 16.x, 18.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.2.2
       - name: Use Node Version ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -41,7 +41,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4.2.2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -49,7 +49,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4.2.2
         name: Cache node_modules
         id: cache-node-modules
         with:
@@ -58,24 +58,24 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4.2.2
         name: Cache Jest cache
         id: cache-jest-cache
         with:
           path: .jest-cache
-          key: ${{ runner.os }}-${{ matrix.node-version }}-jest        
+          key: ${{ runner.os }}-${{ matrix.node-version }}-jest
 
       - name: Install Dependencies
         run: yarn --frozen-lockfile
         if: steps.cache-yarn-cache.outputs.cache-hit != 'true' || steps.cache-node-modules.outputs.cache-hit != 'true'
-      
+
       - name: Unit tests
         run: yarn test --all --cacheDirectory .jest-cache --coverage --watchAll false
       - uses: vebr/jest-lcov-reporter@v0.2.1
         # Print comment only on 1 build and PR
         if: matrix.node-version == '14.x' && github.event_name == 'pull_request'
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}  
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   release:
     runs-on: ubuntu-latest
@@ -84,7 +84,7 @@ jobs:
     if: contains(github.ref, 'tag')
     needs: build
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4.2.2
 
     - name: Use Node Version 14.x
       uses: actions/setup-node@v1
@@ -97,7 +97,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4.2.2
       id: yarn-cache
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -110,7 +110,7 @@ jobs:
       if: steps.cache-yarn-cache.outputs.cache-hit != 'true' || steps.cache-node-modules.outputs.cache-hit != 'true'
 
     - name: Build package
-      run: yarn build     
+      run: yarn build
 
     - name: Publish package
       run: npm publish --production --access public


### PR DESCRIPTION
## Description

Upgrade Github action cache and checkout to version 4.x

## Motivation and Context

Action cache v2 has been deprecated and no longer works

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
