### PR TITLE
feat: add new "tab" command to execCommand

### DIFF
--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -52,6 +52,12 @@ export interface IExecCommandReturnValue {
   data?: Record<string, unknown>
 }
 
+export enum SidebarTabs {
+  CONTENT = 'content',
+  SETTINGS = 'settings',
+  ROWS = 'rows',
+}
+
 export type ExecCommand = Promise<IExecCommandReturnValue>
 
 export enum ExecCommands {
@@ -59,6 +65,7 @@ export enum ExecCommands {
   SCROLL = 'scroll',
   HIGHLIGHT = 'highlight',
   FOCUS = 'focus',
+  TAB = 'tab',
 }
 
 export interface IExecCommandOptions {
@@ -69,7 +76,7 @@ export interface IExecCommandOptions {
     module?: number
     key?: string
     selector?: string
-  }
+  } | SidebarTabs
 }
 
 export enum LoadWorkspaceOptions {


### PR DESCRIPTION
## Description

New command "tab" (types only) for `execCommand` method (Custom Commands)

## Motivation and Context

Allow the API to use the new command to programmatically change the Sidebar tab.

## Usage examples

```js 

await BeefreeSDK.execCommand('tab', { target: 'settings' })

```

