### PR TITLE
Chore: Update auth url with login v2

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -6,7 +6,7 @@ export const fetchToken = ({ authUrl, clientId, clientSecret, uid }:IFetchTokenP
     grant_type: 'password',
     client_id: clientId,
     client_secret: clientSecret,
-    uid
+    uid,
   }
   return axios.post(authUrl, payload)
 }

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -33,6 +33,6 @@ export const mockedEmptyToken : IToken = {
 
 export const BEEJS_URL = 'https://app-rsrc.getbee.io/plugin/v2/BeePlugin.js'
 
-export const API_AUTH_URL = 'https://auth.getbee.io/apiauth'
+export const API_AUTH_URL = 'https://auth.getbee.io/loginV2'
 
 export default beeActions


### PR DESCRIPTION
## Description

Update Auth URL to use login v2

## Motivation and Context

Old login endpoint will be deprecated

## Types of changes

- [x] Added semicolon
- [x] API_AUTH_URL now uses the new `/loginV2` endpoint

