### PR TITLE
feat(types): add qualityCheck config to IBeeConfig

### DIFF
--- a/src/types/bee.ts
+++ b/src/types/bee.ts
@@ -3079,6 +3079,31 @@ export type SelectedElement = {
   uuid: string
 }
 
+export type QualityCheckCategory =
+  | 'missingAltText'
+  | 'missingImageLink'
+  | 'missingCopyLink'
+  | 'missingHeadings'
+  | 'overageHeadings'
+  | 'overageImageWeight'
+  | 'missingDetailsEmail'
+  | 'overageHtmlWeight'
+  | 'missingMainLanguage'
+  | 'insufficientColorContrast'
+  | 'insufficientFontSize'
+  | 'missingDetailsPage'
+
+export interface QualityCheckTypeConfig {
+  thresholds?: Record<string, number>
+  checks?: QualityCheckCategory[]
+}
+
+export interface QualityCheckConfig {
+  email?: QualityCheckTypeConfig
+  page?: QualityCheckTypeConfig
+  row?: QualityCheckTypeConfig
+}
+
 export interface IBeeConfig {
   container: IBeeContainer
   uid?: string
@@ -3168,6 +3193,7 @@ export interface IBeeConfig {
   metadata?: {
     languages: MetadataLanguage[]
   }
+  qualityCheck?: QualityCheckConfig
 }
 
 export interface IBeeConfigFileManager {


### PR DESCRIPTION
## Description

Adds Quality Check configuration types to the SDK type surface:

- `QualityCheckCategory` — union of the 12 check identifiers (mirrors `SmartChecks` in the SDK frontend `CheckerPanel`)
- `QualityCheckTypeConfig` — `{ thresholds?, checks? }`
- `QualityCheckConfig` — split by content type: `{ email?, page?, row? }`
- `qualityCheck?: QualityCheckConfig` field on `IBeeConfig`

## Motivation and Context

The SDK frontend `CheckerPanel` consumes a `qualityCheck` config (`sdk-frontend/src/providers/ApiProvider/types.ts`, wired via `ClientConfig`), but the public SDK types did not expose it. This lets integrators type their `qualityCheck` config against `@beefree.io/sdk`.

BEE-11970

## Usage examples

```js
import BeefreeSDK from '@beefree.io/sdk'

const sdk = new BeefreeSDK()
sdk.start({
  qualityCheck: {
    email: {
      checks: ['missingAltText', 'insufficientColorContrast'],
      thresholds: { overageImageWeight: 500 },
    },
  },
})
```

## How Has This Been Tested?

`npx tsc --noEmit` passes. Type-only change; no runtime behavior affected.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)